### PR TITLE
tfs-unlock uses promises, change the checkout command to handle promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = function (opts) {
         cb();
       }, function () {
         this.emit('error', new gutil.PluginError('gulp-tfs-checkout', null, {fileName: file.path}));
+        cb();
       });
 			
 		} catch (err) {

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ module.exports = function (opts) {
 			tfs.checkout([file.path]).then(function () {
         gutil.log('Checked out file "' + file.path + '"');
         cb();
-      }, function () {
-        this.emit('error', new gutil.PluginError('gulp-tfs-checkout', null, {fileName: file.path}));
+      }, function (error) {
+        gutil.log(gutil.colors.yellow('Warning: Unable to checkout: ' + file.path + ' - Check that this file is under source control and tf.exe works properlly with this file.'));
         cb();
       });
 			

--- a/index.js
+++ b/index.js
@@ -22,12 +22,15 @@ module.exports = function (opts) {
 
 		try {
 			tfs.init();
-			tfs.checkout([file.path]);
-			gutil.log('Checked out file "' + file.path + '"');
+			tfs.checkout([file.path]).then(function () {
+        gutil.log('Checked out file "' + file.path + '"');
+        cb();
+      }, function () {
+        this.emit('error', new gutil.PluginError('gulp-tfs-checkout', null, {fileName: file.path}));
+      });
+			
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-tfs-checkout', err, {fileName: file.path}));
 		}
-
-		cb();
 	});
 };


### PR DESCRIPTION
The old code assumed that the tfs.checkout call ran synchronously. This is not the case. It returns a promise. Without waiting for the promise to resolve the stream would continue processing and could act on files which had not *yet* been checked out.

This pull request changes the execution such that the tfs.checkout call waits for the promise to resolve and then calls the callback method ````cb()````.