### PR TITLE
pass file as second arguments of callback on tfs checkout

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,12 +24,12 @@ module.exports = function (opts) {
 			tfs.init();
 			tfs.checkout([file.path]).then(function () {
         gutil.log('Checked out file "' + file.path + '"');
-        cb();
+        cb(null, file);
       }, function (error) {
         gutil.log(gutil.colors.yellow('Warning: Unable to checkout: ' + file.path + ' - Check that this file is under source control and tf.exe works properlly with this file.'));
-        cb();
+        cb(null, file);
       });
-			
+
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-tfs-checkout', err, {fileName: file.path}));
 		}


### PR DESCRIPTION
If file is not passed as second arguments I can't make tasks after tfs ones, so it's a big problem in my case.